### PR TITLE
templates path fix

### DIFF
--- a/Collector/Gateways/view/frontend/layout/sales_order_view.xml
+++ b/Collector/Gateways/view/frontend/layout/sales_order_view.xml
@@ -12,7 +12,7 @@
 			<block class="Collector\Gateways\Block\Sales\Order\Fee" name="fee"/>
 		</referenceContainer>
 		<referenceContainer name="payment_additional_info">
-			<block class="Collector\Gateways\Block\Adminhtml\PaymentInfo" template="PaymentInfo.phtml" name="paymentinfo"/>
+			<block class="Collector\Gateways\Block\Adminhtml\PaymentInfo" template="Collector_Gateways::PaymentInfo.phtml" name="paymentinfo"/>
 		</referenceContainer>
 	</body>
 </page>

--- a/Collector/Iframe/view/frontend/layout/collectorcheckout_cajax_cajax.xml
+++ b/Collector/Iframe/view/frontend/layout/collectorcheckout_cajax_cajax.xml
@@ -10,11 +10,11 @@
 		</referenceContainer>
 		<referenceContainer name="page.wrapper">
 			<container name="collector-cart" htmlTag="div" htmlClass="collector-cart-wrapper" after="header-wrapper">
-				<block class="Collector\Iframe\Block\Cart" cacheable="false" name="collectorjscart" template="Cartjs.phtml" before="main" after="header-wrapper" />
-				<block class="Collector\Iframe\Block\Cart" cacheable="false" name="collectorcart" template="Cart.phtml" before="main" after="header-wrapper" />
+				<block class="Collector\Iframe\Block\Cart" cacheable="false" name="collectorjscart" template="Collector_Iframe::Cartjs.phtml" before="main" after="header-wrapper" />
+				<block class="Collector\Iframe\Block\Cart" cacheable="false" name="collectorcart" template="Collector_Iframe::Cart.phtml" before="main" after="header-wrapper" />
 			</container>
 			<container name="collector-checkout" htmlTag="div" htmlClass="collector-checkout-wrapper" after="collector-cart">
-				<block class="Collector\Iframe\Block\Checkout" cacheable="false" name="collectorcheckout" template="Checkout.phtml" after="collector-cart"/>
+				<block class="Collector\Iframe\Block\Checkout" cacheable="false" name="collectorcheckout" template="Collector_Iframe::Checkout.phtml" after="collector-cart"/>
 			</container>
 		</referenceContainer>
 	</body>

--- a/Collector/Iframe/view/frontend/layout/collectorcheckout_index_index.xml
+++ b/Collector/Iframe/view/frontend/layout/collectorcheckout_index_index.xml
@@ -14,12 +14,12 @@
 		</referenceContainer>
 		<referenceContainer name="page.wrapper">
 			<container name="collector-cart" htmlTag="div" htmlClass="collector-cart-wrapper" after="header-wrapper">
-				<block class="Collector\Iframe\Block\Cart" cacheable="false" name="collectorjscart" template="Cartjs.phtml" before="main" after="header-wrapper" />
-				<block class="Collector\Iframe\Block\Cart" cacheable="false" name="collectorcart" template="Cart.phtml" before="main" after="header-wrapper" />
+				<block class="Collector\Iframe\Block\Cart" cacheable="false" name="collectorjscart" template="Collector_Iframe::Cartjs.phtml" before="main" after="header-wrapper" />
+				<block class="Collector\Iframe\Block\Cart" cacheable="false" name="collectorcart" template="Collector_Iframe::Cart.phtml" before="main" after="header-wrapper" />
 			</container>
 			<container name="collector-checkout" htmlTag="div" htmlClass="collector-checkout-wrapper" after="collector-cart">
-				<block class="Collector\Iframe\Block\Checkout" cacheable="false" name="collectorjscheckout" template="Checkoutjs.phtml" before="main" after="collector-cart" />
-				<block class="Collector\Iframe\Block\Checkout" cacheable="false" name="collectorcheckout" template="Checkout.phtml" after="collector-cart"/>
+				<block class="Collector\Iframe\Block\Checkout" cacheable="false" name="collectorjscheckout" template="Collector_Iframe::Checkoutjs.phtml" before="main" after="collector-cart" />
+				<block class="Collector\Iframe\Block\Checkout" cacheable="false" name="collectorcheckout" template="Collector_Iframe::Checkout.phtml" after="collector-cart"/>
 			</container>
 		</referenceContainer>
 	</body>

--- a/Collector/Iframe/view/frontend/layout/collectorcheckout_success_index.xml
+++ b/Collector/Iframe/view/frontend/layout/collectorcheckout_success_index.xml
@@ -13,7 +13,7 @@
 			<container name="div.sidebar.main" htmlTag="div" htmlClass="sidebar sidebar-main" after="main">
 			</container>
 			<container name="column.main" htmlTag="div" htmlClass="column main" before="main"> <!--   -->
-				<block class="Collector\Iframe\Block\Checkout" cacheable="false" name="collectorcheckoutsuccess" template="Success.phtml" />
+				<block class="Collector\Iframe\Block\Checkout" cacheable="false" name="collectorcheckoutsuccess" template="Collector_Iframe::Success.phtml" />
 			</container>
 		</referenceContainer>
     </body>

--- a/Collector/Iframe/view/frontend/layout/collectorcheckout_test_test.xml
+++ b/Collector/Iframe/view/frontend/layout/collectorcheckout_test_test.xml
@@ -10,7 +10,7 @@
 		</referenceContainer>
 		<referenceContainer name="page.wrapper">
 			<container name="collector-test" htmlTag="div" htmlClass="collector-test-wrapper" after="header-wrapper">
-				<block class="Collector\Iframe\Block\Test" cacheable="false" name="collectortest" template="Test.phtml" before="main" after="header-wrapper" />
+				<block class="Collector\Iframe\Block\Test" cacheable="false" name="collectortest" template="Collector_Iframe::Test.phtml" before="main" after="header-wrapper" />
 			</container>
 		</referenceContainer>
 	</body>


### PR DESCRIPTION
When you override Collectorcheckout\Iframe\Block\Cart you need to copy all the templates into you custom module.