### PR TITLE
Send shipping code and shipping description

### DIFF
--- a/Collector/Iframe/Helper/Data.php
+++ b/Collector/Iframe/Helper/Data.php
@@ -453,24 +453,24 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         if (!empty($shippingAddress->getShippingMethod())) {
 			if ($this->apiRequest->convert($shippingAddress->getShippingInclTax(), 'SEK') !== NULL){
 				$ret ['shipping'] = [
-					'id' => "shipping",
-					'description' => $shippingAddress->getShippingMethod(),
+					'id' => $shippingAddress->getShippingMethod(),
+					'description' => $shippingAddress->getShippingDescription(),
 					'unitPrice' => $this->apiRequest->convert($shippingAddress->getShippingInclTax(), 'SEK'),
 					'vat' => 0
 				];
 			}
 			else {
 				$ret ['shipping'] = [
-					'id' => "shipping",
-					'description' => $shippingAddress->getShippingMethod(),
+					'id' => $shippingAddress->getShippingMethod(),
+					'description' => $shippingAddress->getShippingDescription(),
 					'unitPrice' => 0,
 					'vat' => 0
 				];
 			}
         } else {
             $ret['shipping'] = [
-                'id' => 'shipping',
-                'description' => 'freeshipping_freeshipping',
+                'id' => 'freeshipping_freeshipping',
+                'description' => __('Free Shipping'),
                 'unitPrice' => 0,
                 'vat' => '0'
             ];


### PR DESCRIPTION
Hi!

Our merchants requested that we don't display shipping code in receipt customers receive after checkout
https://prnt.sc/l4a63g

I suggest sending shipping code in `id` field, and shipping description in according field.
https://prnt.sc/l7jxt1
https://prnt.sc/l7jxv9

Thanks!